### PR TITLE
(maint) Add instruction about forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ intern-test
 ===========
 
 A place for the interns to practice their git-fu
+
+You should have your own fork for most of the work.


### PR DESCRIPTION
Prior to this commit, the README did not specify that someone would need
to fork the `intern-test` repository for attempting to work with it.
This commit adds instructions to fork the repo first.
