### PR TITLE
(PE-3333) Add blah message to my_email

### DIFF
--- a/my_email
+++ b/my_email
@@ -6,7 +6,7 @@ chris.hoge@puppetlabs.com
 
 
 I have other emails as well, but please don't use them
-
+BLAH
 
 this, my friends, is correct
 


### PR DESCRIPTION
Prior to this commit, the blah message was not present.  This commit fixes
this oversight and added the excellent word blah to the my_email file.
